### PR TITLE
Update summary page for tags support

### DIFF
--- a/src/org/ecs160/a2/AppMain.java
+++ b/src/org/ecs160/a2/AppMain.java
@@ -12,6 +12,7 @@ import org.ecs160.a2.ui.TaskEditor;
 
 import org.ecs160.a2.ui.Summary;
 import org.ecs160.a2.ui.TaskList;
+import org.ecs160.a2.ui.containers.UpdateableContainer;
 import org.ecs160.a2.utils.Database;
 
 import java.io.IOException;
@@ -107,6 +108,17 @@ public class AppMain {
       tabs.addTab("Tasks", taskIcon, new TaskList(this.current.getToolbar()));
       tabs.addTab("Summary", summaryIcon, new Summary());
       tabs.setSwipeActivated(false); // Disable the swipe to prevent competition with the cards
+      tabs.addSelectionListener((i, j) -> tabSelectionListener(tabs, i, j));
    }
 
+   private void tabSelectionListener (Tabs origin, int oldIndex, int newIndex) {
+      if (oldIndex == newIndex) return;
+      switch (newIndex) {
+         case 1:
+            UpdateableContainer container;
+            container = ((UpdateableContainer) origin.getTabComponentAt(1));
+            container.updateContainer(null);
+            break;
+      }
+   }
 }

--- a/src/org/ecs160/a2/ui/Summary.java
+++ b/src/org/ecs160/a2/ui/Summary.java
@@ -1,15 +1,16 @@
 package org.ecs160.a2.ui;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import com.codename1.ui.Button;
+import com.codename1.ui.Component;
 import com.codename1.ui.Container;
-import com.codename1.ui.events.ActionEvent;
 import com.codename1.ui.layouts.BoxLayout;
 import com.codename1.ui.layouts.GridLayout;
+import com.codename1.ui.plaf.RoundRectBorder;
+import com.codename1.ui.plaf.Style;
 
 import org.ecs160.a2.models.Task;
 import org.ecs160.a2.ui.containers.UpdateableContainer;
@@ -43,7 +44,14 @@ public class Summary extends UpdateableContainer implements AppConstants {
         this.pages = new HashMap<>();
 
         // page button container setup
+        // set the background styling
+        int marginSize = UIUtils.getPixelSize(FONT_SIZE_REGULAR / 2.0f);
         pageButtonContainer = new Container();
+        pageButtonContainer.getAllStyles().setBgColor(0xD3D3D3);
+        pageButtonContainer.getAllStyles().setBgTransparency(255);
+        pageButtonContainer.getAllStyles().setBorder(RoundRectBorder.create());
+        pageButtonContainer.getAllStyles().setMargin(Component.TOP, marginSize);
+        pageButtonContainer.getAllStyles().setMargin(Component.BOTTOM, marginSize);
         this.add(pageButtonContainer);
 
         // setup pages
@@ -62,12 +70,28 @@ public class Summary extends UpdateableContainer implements AppConstants {
     }
 
     // method to construct page buttons
+    // set the selection styles (default to background transparent)
     private void addPageButton (String text) {
         Button pageButton = new Button (text);
+        pageButton.getAllStyles().setFgColor(0x000000); // black font
+        pageButton.getAllStyles().setBgColor(0xffffff); // white background
+        pageButton.getAllStyles().setBorder(RoundRectBorder.create());
         pageButton.addActionListener((e) -> {
             selectPage(((Button) e.getComponent()).getText());
         });
         pageButtonContainer.add(pageButton);
+    }
+
+    // update selected button styles by updating the transparencies
+    private void setSelectedButtonStyle (String text) {
+        for (int i = 0; i < pageButtonContainer.getComponentCount(); i++) {
+            Button button = (Button) pageButtonContainer.getComponentAt(i);
+            if (button.getText().equals(text)) { // if equal, make bg visible
+                button.getAllStyles().setBgTransparency(255);
+            } else {
+                button.getAllStyles().setBgTransparency(0);
+            }
+        }
     }
 
     // method to add a new page
@@ -80,6 +104,7 @@ public class Summary extends UpdateableContainer implements AppConstants {
 
     // select a page for the given button text
     private void selectPage (String text) {
+        setSelectedButtonStyle(text);
         this.pages.forEach((key, value) -> value.setHidden(true));
         this.pages.get(text).updateContainer(taskList);
         this.pages.get(text).setHidden(false);

--- a/src/org/ecs160/a2/ui/Summary.java
+++ b/src/org/ecs160/a2/ui/Summary.java
@@ -10,7 +10,6 @@ import com.codename1.ui.Container;
 import com.codename1.ui.layouts.BoxLayout;
 import com.codename1.ui.layouts.GridLayout;
 import com.codename1.ui.plaf.RoundRectBorder;
-import com.codename1.ui.plaf.Style;
 
 import org.ecs160.a2.models.Task;
 import org.ecs160.a2.ui.containers.UpdateableContainer;

--- a/src/org/ecs160/a2/ui/Summary.java
+++ b/src/org/ecs160/a2/ui/Summary.java
@@ -56,7 +56,7 @@ public class Summary extends UpdateableContainer implements AppConstants {
         // setup pages
         this.addPage("Everything", new SummaryAll());
         this.addPage("By Size", new SummarySize());
-        this.addPage("By Tags", new SummaryTags());
+        this.addPage("By Tag", new SummaryTags());
 
         // revalidate the button container
         pageButtonContainer.setLayout(new GridLayout(1, this.pages.size()));

--- a/src/org/ecs160/a2/ui/Summary.java
+++ b/src/org/ecs160/a2/ui/Summary.java
@@ -22,7 +22,14 @@ public class Summary extends UpdateableContainer implements AppConstants {
     // the current state of TaskList for this page
     private static List<Task> taskList;
 
-    private UpdateableContainer page1, page2;
+    private UpdateableContainer page1, page2, page3;
+
+    // method to construct page buttons
+    private void addPageButton (Container buttonContainer, String text) {
+        Button pageButton = new Button (text);
+        pageButton.addActionListener((e) -> selectPageButtonAction(e));
+        buttonContainer.add(pageButton);
+    }
 
     /**
      * Default constructor that assembles the children of this container
@@ -36,13 +43,10 @@ public class Summary extends UpdateableContainer implements AppConstants {
                                      FONT_SIZE_TITLE));
 
         // Selection
-        Container buttonContainer = new Container(new GridLayout(1, 2));
-        Button page1Button = new Button ("Everything");
-        page1Button.addActionListener((e) -> selectPageButtonAction(e));
-        buttonContainer.add(page1Button);
-        Button page2Button = new Button ("By Size");
-        page2Button.addActionListener((e) -> selectPageButtonAction(e));
-        buttonContainer.add(page2Button);
+        Container buttonContainer = new Container(new GridLayout(1, 3));
+        addPageButton(buttonContainer, "Everything");
+        addPageButton(buttonContainer, "By Size");
+        addPageButton(buttonContainer, "By Tags");
         this.add(buttonContainer);
 
         // setup the different summary pages
@@ -52,6 +56,9 @@ public class Summary extends UpdateableContainer implements AppConstants {
         this.page2 = new SummarySize();
         this.page2.setHidden(true); // default hidden
         this.add(this.page2);
+        this.page3 = new SummaryTags();
+        this.page3.setHidden(true); // default hidden
+        this.add(this.page3);
 
         // Setup pull to refresh for this container
         this.addPullToRefresh(() -> updateSubContainers());
@@ -64,12 +71,18 @@ public class Summary extends UpdateableContainer implements AppConstants {
         Button button = (Button) e.getComponent();
         switch (button.getText()) {
             case "Everything":
+                this.page3.setHidden(true);
                 this.page2.setHidden(true);
                 this.page1.setHidden(false);
                 break;
             case "By Size":
-                this.page1.setHidden(true);
+                this.page3.setHidden(true);
                 this.page2.setHidden(false);
+                this.page1.setHidden(true);
+            case "By Tags":
+                this.page3.setHidden(false);
+                this.page2.setHidden(true);
+                this.page1.setHidden(true);
         }
     }
 

--- a/src/org/ecs160/a2/ui/SummaryTags.java
+++ b/src/org/ecs160/a2/ui/SummaryTags.java
@@ -1,0 +1,76 @@
+package org.ecs160.a2.ui;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.codename1.ui.Display;
+import com.codename1.ui.layouts.BoxLayout;
+import com.codename1.ui.spinner.Picker;
+
+import org.ecs160.a2.models.Task;
+import org.ecs160.a2.ui.containers.UpdateableContainer;
+import org.ecs160.a2.ui.containers.TaskContainer;
+import org.ecs160.a2.ui.containers.StatsContainer;
+import org.ecs160.a2.utils.AppConstants;
+import org.ecs160.a2.utils.UIUtils;
+
+/**
+ * The container that houses the Summary containers for different sizes
+ */
+public class SummaryTags extends UpdateableContainer implements AppConstants {
+
+    // label containers
+    private UpdateableContainer tasks, stats;
+
+    // picker that allows the selection of sizes
+    private Picker sizePicker;
+
+    /**
+     * Assemble the children of this container
+     */
+    public SummaryTags () {
+        super(new BoxLayout(BoxLayout.Y_AXIS));
+
+        // size picker that updates everything on state change
+        String[] sizes = Task.sizes.toArray(new String[Task.sizes.size()]);
+        this.sizePicker = new Picker();
+        this.sizePicker.setType(Display.PICKER_TYPE_STRINGS);
+        this.sizePicker.setStrings(sizes);
+        this.sizePicker.setSelectedStringIndex(1); // default to "S"
+        this.sizePicker.addActionListener((e) -> askParentForUpdate());
+        this.add(this.sizePicker);
+
+        // Tasks
+        this.add(UIUtils.createLabel("Tasks", NATIVE_BOLD, COLOR_TITLE,
+                                     FONT_SIZE_SUB_TITLE));
+        this.tasks = new TaskContainer();
+        this.add(this.tasks);
+
+        // Stats
+        this.add(UIUtils.createLabel("Statistics", NATIVE_BOLD, COLOR_TITLE,
+                                     FONT_SIZE_SUB_TITLE));
+        this.stats = new StatsContainer();
+        this.add(this.stats);
+    }
+
+    // filter a task list for the specified size
+    private List<Task> filterTaskList(List<Task> taskList, String size) {
+        List<Task> returnList = new ArrayList<Task>();
+        for (Task task : taskList) {
+            if (task.getSize().equals(size)) returnList.add(task);
+        }
+        return returnList;
+    }
+
+    /**
+     * Update the sub containers after filtering the Task List for the current
+     * size
+     */
+    @Override
+    public void updateContainer(List<Task> taskList) {   
+        List<Task> filteredList;
+        filteredList = filterTaskList(taskList, sizePicker.getSelectedString());
+        this.tasks.updateContainer(filteredList);
+        this.stats.updateContainer(filteredList);
+    }
+}

--- a/src/org/ecs160/a2/ui/SummaryTags.java
+++ b/src/org/ecs160/a2/ui/SummaryTags.java
@@ -10,6 +10,7 @@ import com.codename1.ui.spinner.Picker;
 import org.ecs160.a2.models.Task;
 import org.ecs160.a2.ui.containers.UpdateableContainer;
 import org.ecs160.a2.ui.containers.TaskContainer;
+import org.ecs160.a2.ui.containers.SizeContainer;
 import org.ecs160.a2.ui.containers.StatsContainer;
 import org.ecs160.a2.utils.AppConstants;
 import org.ecs160.a2.utils.UIUtils;
@@ -20,10 +21,13 @@ import org.ecs160.a2.utils.UIUtils;
 public class SummaryTags extends UpdateableContainer implements AppConstants {
 
     // label containers
-    private UpdateableContainer tasks, stats;
+    private UpdateableContainer tasks, sizes, stats;
 
-    // picker that allows the selection of sizes
-    private Picker sizePicker;
+    // picker that allows the selection of tags
+    private Picker tagsPicker;
+
+    // tags list
+    private List<String> tagsList;
 
     /**
      * Assemble the children of this container
@@ -31,20 +35,25 @@ public class SummaryTags extends UpdateableContainer implements AppConstants {
     public SummaryTags () {
         super(new BoxLayout(BoxLayout.Y_AXIS));
 
+        this.tagsList = new ArrayList<>();
+
         // size picker that updates everything on state change
-        String[] sizes = Task.sizes.toArray(new String[Task.sizes.size()]);
-        this.sizePicker = new Picker();
-        this.sizePicker.setType(Display.PICKER_TYPE_STRINGS);
-        this.sizePicker.setStrings(sizes);
-        this.sizePicker.setSelectedStringIndex(1); // default to "S"
-        this.sizePicker.addActionListener((e) -> askParentForUpdate());
-        this.add(this.sizePicker);
+        this.tagsPicker = new Picker();
+        this.tagsPicker.setType(Display.PICKER_TYPE_STRINGS);
+        this.tagsPicker.addActionListener((e) -> askParentForUpdate());
+        this.add(this.tagsPicker);
 
         // Tasks
         this.add(UIUtils.createLabel("Tasks", NATIVE_BOLD, COLOR_TITLE,
                                      FONT_SIZE_SUB_TITLE));
         this.tasks = new TaskContainer();
         this.add(this.tasks);
+
+        // Sizes
+        this.add(UIUtils.createLabel("Sizes", NATIVE_BOLD, COLOR_TITLE,
+                                     FONT_SIZE_SUB_TITLE));
+        this.sizes = new SizeContainer();
+        this.add(this.sizes);  
 
         // Stats
         this.add(UIUtils.createLabel("Statistics", NATIVE_BOLD, COLOR_TITLE,
@@ -57,9 +66,20 @@ public class SummaryTags extends UpdateableContainer implements AppConstants {
     private List<Task> filterTaskList(List<Task> taskList, String size) {
         List<Task> returnList = new ArrayList<Task>();
         for (Task task : taskList) {
-            if (task.getSize().equals(size)) returnList.add(task);
+            if (task.getTags().contains(size)) returnList.add(task);
         }
         return returnList;
+    }
+
+    private void buildTagsPicker(List<Task> taskList) {
+        this.tagsList.clear();
+        for (Task task : taskList) {
+            for (String tag : task.getTags()) {
+                this.tagsList.add(tag);
+            }
+        }
+        String[] tags = tagsList.toArray(new String[tagsList.size()]);
+        this.tagsPicker.setStrings(tags);
     }
 
     /**
@@ -68,9 +88,11 @@ public class SummaryTags extends UpdateableContainer implements AppConstants {
      */
     @Override
     public void updateContainer(List<Task> taskList) {   
+        this.buildTagsPicker(taskList);
         List<Task> filteredList;
-        filteredList = filterTaskList(taskList, sizePicker.getSelectedString());
+        filteredList = filterTaskList(taskList, tagsPicker.getSelectedString());
         this.tasks.updateContainer(filteredList);
+        this.sizes.updateContainer(filteredList);
         this.stats.updateContainer(filteredList);
     }
 }

--- a/src/org/ecs160/a2/ui/containers/SizeContainer.java
+++ b/src/org/ecs160/a2/ui/containers/SizeContainer.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.codename1.components.SpanLabel;
 import com.codename1.ui.Label;
 import com.codename1.ui.layouts.BoxLayout;
 
@@ -18,8 +19,15 @@ import org.ecs160.a2.utils.UIUtils;
 public class SizeContainer extends UpdateableContainer 
                            implements AppConstants {
 
+    private SpanLabel sizesLabel;
+
     public SizeContainer () {
         super(new BoxLayout(BoxLayout.Y_AXIS));
+        this.sizesLabel = UIUtils.createSpanLabel("",
+                                                  NATIVE_LIGHT, 
+                                                  COLOR_REGULAR,
+                                                  FONT_SIZE_REGULAR);
+        this.add(this.sizesLabel);
     }
 
     /**
@@ -27,6 +35,7 @@ public class SizeContainer extends UpdateableContainer
      */
     @Override
     public void updateContainer(List<Task> taskList) {
+        String labelText = "";
         // use a map to keep track of the current totals for the sizes
         Map<String, Long> sizeStatsMap = new HashMap<String, Long>();
 
@@ -43,18 +52,24 @@ public class SizeContainer extends UpdateableContainer
         // make sure label count is proper, then update the text
         Object[] availableSizes = sizeStatsMap.keySet().toArray();
 
+        // build the new label text
         int numSizes = sizeStatsMap.keySet().size();
-        List<Label> labels = UIUtils.getLabelsToUpdate(this, 
-                                                       numSizes);
         for (int i = 0; i < numSizes; i++) {
+            if (i > 0) labelText += "\n";
+
             String size = (String) availableSizes[i];
-            Label label = labels.get(i);
             long sizeTime = sizeStatsMap.get(size);
 
             // update label text
-            label.setText(" - " +
-                          DurationUtils.timeAsLabelStr(sizeTime) +
-                          " total for " + size);
+            labelText += " - " +
+                         DurationUtils.timeAsLabelStr(sizeTime) +
+                         " total for " + size;
         }
+
+        // update the text of the internal label
+        this.sizesLabel.setText(labelText);
+        if (labelText.length() == 0) this.sizesLabel.setHidden(true);
+        else this.sizesLabel.setHidden(false);
+        this.forceRevalidate();
     }
 }

--- a/src/org/ecs160/a2/ui/containers/SizeContainer.java
+++ b/src/org/ecs160/a2/ui/containers/SizeContainer.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.Map;
 
 import com.codename1.components.SpanLabel;
-import com.codename1.ui.Label;
 import com.codename1.ui.layouts.BoxLayout;
 
 import org.ecs160.a2.models.Task;

--- a/src/org/ecs160/a2/ui/containers/SizeContainer.java
+++ b/src/org/ecs160/a2/ui/containers/SizeContainer.java
@@ -29,7 +29,7 @@ public class SizeContainer extends UpdateableContainer
                                                   COLOR_REGULAR,
                                                   FONT_SIZE_REGULAR);
         this.totalLabel = UIUtils.createLabel("Total Time: 0s",
-                                              NATIVE_ITALIC_LIGHT,
+                                              NATIVE_ITAL_LIGHT,
                                               COLOR_REGULAR,
                                               FONT_SIZE_REGULAR);
         this.add(this.sizesLabel);

--- a/src/org/ecs160/a2/ui/containers/SizeContainer.java
+++ b/src/org/ecs160/a2/ui/containers/SizeContainer.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.codename1.components.SpanLabel;
+import com.codename1.ui.Label;
 import com.codename1.ui.layouts.BoxLayout;
 
 import org.ecs160.a2.models.Task;
@@ -19,6 +20,7 @@ public class SizeContainer extends UpdateableContainer
                            implements AppConstants {
 
     private SpanLabel sizesLabel;
+    private Label totalLabel;
 
     public SizeContainer () {
         super(new BoxLayout(BoxLayout.Y_AXIS));
@@ -26,7 +28,12 @@ public class SizeContainer extends UpdateableContainer
                                                   NATIVE_LIGHT, 
                                                   COLOR_REGULAR,
                                                   FONT_SIZE_REGULAR);
+        this.totalLabel = UIUtils.createLabel("Total Time: 0s",
+                                              NATIVE_ITALIC_LIGHT,
+                                              COLOR_REGULAR,
+                                              FONT_SIZE_REGULAR);
         this.add(this.sizesLabel);
+        this.add(this.totalLabel);
     }
 
     /**
@@ -34,7 +41,10 @@ public class SizeContainer extends UpdateableContainer
      */
     @Override
     public void updateContainer(List<Task> taskList) {
+        // variables used to update labels
         String labelText = "";
+        long totalTime = 0L;
+
         // use a map to keep track of the current totals for the sizes
         Map<String, Long> sizeStatsMap = new HashMap<String, Long>();
 
@@ -59,11 +69,18 @@ public class SizeContainer extends UpdateableContainer
             String size = (String) availableSizes[i];
             long sizeTime = sizeStatsMap.get(size);
 
+            // add to the total time
+            totalTime += sizeTime;
+
             // update label text
             labelText += " - " +
                          DurationUtils.timeAsLabelStr(sizeTime) +
                          " total for " + size;
         }
+
+        // update total time label
+        this.totalLabel.setText("Total Time: " +
+                                DurationUtils.timeAsLabelStr(totalTime));
 
         // update the text of the internal label
         this.sizesLabel.setText(labelText);

--- a/src/org/ecs160/a2/ui/containers/SizeContainer.java
+++ b/src/org/ecs160/a2/ui/containers/SizeContainer.java
@@ -22,6 +22,7 @@ public class SizeContainer extends UpdateableContainer
     private SpanLabel sizesLabel;
     private Label totalLabel;
 
+    // inner container constructor
     public SizeContainer () {
         super(new BoxLayout(BoxLayout.Y_AXIS));
         this.sizesLabel = UIUtils.createSpanLabel("",
@@ -36,6 +37,24 @@ public class SizeContainer extends UpdateableContainer
         this.add(this.totalLabel);
     }
 
+    // get size totals for each map available in the task list
+    private Map<String, Long> getTaskSizeTotals (List<Task> taskList) {
+        // use a map to keep track of the current totals for the sizes
+        Map<String, Long> returnMap = new HashMap<String, Long>();
+
+        // add up totals for the different sizes
+        for (Task task : taskList) {
+            if (task.getSize().equals("None")) continue; // no empty
+            long sizeTime = task.getTotalTime();
+            if (returnMap.containsKey(task.getSize())) {
+                sizeTime += returnMap.get(task.getSize());
+            }
+            returnMap.put(task.getSize(), sizeTime);
+        }
+
+        return returnMap;
+    }
+
     /**
      * Update the labels to reflect the statistics for each sizes
      */
@@ -46,17 +65,7 @@ public class SizeContainer extends UpdateableContainer
         long totalTime = 0L;
 
         // use a map to keep track of the current totals for the sizes
-        Map<String, Long> sizeStatsMap = new HashMap<String, Long>();
-
-        // add up totals for the different sizes
-        for (Task task : taskList) {
-            if (task.getSize().equals("None")) continue; // no empty
-            long sizeTime = task.getTotalTime();
-            if (sizeStatsMap.containsKey(task.getSize())) {
-                sizeTime += sizeStatsMap.get(task.getSize());
-            }
-            sizeStatsMap.put(task.getSize(), sizeTime);
-        }
+        Map<String, Long> sizeStatsMap = getTaskSizeTotals(taskList);
 
         // make sure label count is proper, then update the text
         Object[] availableSizes = sizeStatsMap.keySet().toArray();

--- a/src/org/ecs160/a2/ui/containers/StatsContainer.java
+++ b/src/org/ecs160/a2/ui/containers/StatsContainer.java
@@ -2,7 +2,7 @@ package org.ecs160.a2.ui.containers;
 
 import java.util.List;
 
-import com.codename1.ui.Label;
+import com.codename1.components.SpanLabel;
 import com.codename1.ui.layouts.BoxLayout;
 
 import org.ecs160.a2.models.Task;
@@ -16,17 +16,23 @@ import org.ecs160.a2.utils.UIUtils;
 public class StatsContainer extends UpdateableContainer 
                             implements AppConstants {
 
+    private SpanLabel statsLabel;
+
     public StatsContainer () {
         super(new BoxLayout(BoxLayout.Y_AXIS));
+        this.statsLabel = UIUtils.createSpanLabel("",
+                                                  NATIVE_LIGHT, 
+                                                  COLOR_REGULAR,
+                                                  FONT_SIZE_REGULAR);
+        this.add(this.statsLabel);
     }
 
     /**
-     * Update the internal labels to reflect the calculated statistics
+     * Update the internal label to reflect the calculated statistics
      */
     @Override
     public void updateContainer(List<Task> taskList) {
-        // make sure label count is correct
-        List<Label> labels = UIUtils.getLabelsToUpdate(this, 3);
+        String labelText = "";
         long min = -1L, average = -1L, max = -1L;
 
         // calculate the stats
@@ -39,14 +45,20 @@ public class StatsContainer extends UpdateableContainer
         if(taskList.size() > 0) average /= taskList.size();
 
         // update the constant labels
-        labels.get(0).setText(" - " + 
-                              DurationUtils.timeAsLabelStr(min) +
-                              " minimum");
-        labels.get(1).setText(" - " + 
-                              DurationUtils.timeAsLabelStr(max) +
-                              " maximum");
-        labels.get(2).setText(" - " + 
-                              DurationUtils.timeAsLabelStr(average) +
-                              " average");
+        labelText += " - " + 
+                     DurationUtils.timeAsLabelStr(min) +
+                     " minimum\n" +
+                     " - " + 
+                     DurationUtils.timeAsLabelStr(max) +
+                     " maximum\n" +
+                     " - " + 
+                     DurationUtils.timeAsLabelStr(average) +
+                     " average";
+
+        // update the text of the internal label
+        this.statsLabel.setText(labelText);
+        if (labelText.length() == 0) this.statsLabel.setHidden(true);
+        else this.statsLabel.setHidden(false);
+        this.forceRevalidate();
     }
 }

--- a/src/org/ecs160/a2/ui/containers/StatsContainer.java
+++ b/src/org/ecs160/a2/ui/containers/StatsContainer.java
@@ -18,6 +18,7 @@ public class StatsContainer extends UpdateableContainer
 
     private SpanLabel statsLabel;
 
+    // inner container constructor
     public StatsContainer () {
         super(new BoxLayout(BoxLayout.Y_AXIS));
         this.statsLabel = UIUtils.createSpanLabel("",

--- a/src/org/ecs160/a2/ui/containers/TaskContainer.java
+++ b/src/org/ecs160/a2/ui/containers/TaskContainer.java
@@ -20,6 +20,7 @@ public class TaskContainer extends UpdateableContainer
     private SpanLabel tasksLabel;
     private Label totalLabel;
 
+    // inner container constructor
     public TaskContainer () {
         super(new BoxLayout(BoxLayout.Y_AXIS));
         this.tasksLabel = UIUtils.createSpanLabel("",
@@ -27,7 +28,7 @@ public class TaskContainer extends UpdateableContainer
                                                   COLOR_REGULAR,
                                                   FONT_SIZE_REGULAR);
         this.totalLabel = UIUtils.createLabel("Total Time: 0s",
-                                              NATIVE_ITALIC_LIGHT,
+                                              NATIVE_ITAL_LIGHT,
                                               COLOR_REGULAR,
                                               FONT_SIZE_REGULAR);
         this.add(this.tasksLabel);

--- a/src/org/ecs160/a2/ui/containers/TaskContainer.java
+++ b/src/org/ecs160/a2/ui/containers/TaskContainer.java
@@ -3,7 +3,6 @@ package org.ecs160.a2.ui.containers;
 import java.util.List;
 
 import com.codename1.components.SpanLabel;
-import com.codename1.ui.Label;
 import com.codename1.ui.layouts.BoxLayout;
 
 import org.ecs160.a2.models.Task;
@@ -34,13 +33,20 @@ public class TaskContainer extends UpdateableContainer
     @Override
     public void updateContainer(List<Task> taskList) {
         String labelText = "";
+
+        // build the text for the internal label
         for (int i = 0; i < taskList.size(); i++) {
             if (i > 0) labelText += "\n";
+
             Task task = taskList.get(i); // update the label w/ its
+
+            // update label text
             labelText += " - " + 
                          DurationUtils.timeAsLabelStr(task.getTotalTime()) +
                          " total for " + task.getTitle();
         }
+
+        // update the text of the internal label
         this.tasksLabel.setText(labelText);
         if (labelText.length() == 0) this.tasksLabel.setHidden(true);
         else this.tasksLabel.setHidden(false);

--- a/src/org/ecs160/a2/ui/containers/TaskContainer.java
+++ b/src/org/ecs160/a2/ui/containers/TaskContainer.java
@@ -3,6 +3,7 @@ package org.ecs160.a2.ui.containers;
 import java.util.List;
 
 import com.codename1.components.SpanLabel;
+import com.codename1.ui.Label;
 import com.codename1.ui.layouts.BoxLayout;
 
 import org.ecs160.a2.models.Task;
@@ -17,6 +18,7 @@ public class TaskContainer extends UpdateableContainer
                            implements AppConstants {
 
     private SpanLabel tasksLabel;
+    private Label totalLabel;
 
     public TaskContainer () {
         super(new BoxLayout(BoxLayout.Y_AXIS));
@@ -24,7 +26,12 @@ public class TaskContainer extends UpdateableContainer
                                                   NATIVE_LIGHT, 
                                                   COLOR_REGULAR,
                                                   FONT_SIZE_REGULAR);
+        this.totalLabel = UIUtils.createLabel("Total Time: 0s",
+                                              NATIVE_ITALIC_LIGHT,
+                                              COLOR_REGULAR,
+                                              FONT_SIZE_REGULAR);
         this.add(this.tasksLabel);
+        this.add(this.totalLabel);
     }
 
     /**
@@ -32,19 +39,30 @@ public class TaskContainer extends UpdateableContainer
      */
     @Override
     public void updateContainer(List<Task> taskList) {
+        // variables used to update labels
         String labelText = "";
+        long totalTime = 0L;
 
         // build the text for the internal label
         for (int i = 0; i < taskList.size(); i++) {
+            // if second task or later, add a line break
             if (i > 0) labelText += "\n";
 
-            Task task = taskList.get(i); // update the label w/ its
+            // get current task
+            Task task = taskList.get(i);
+
+            // add to the total time
+            totalTime += task.getTotalTime();
 
             // update label text
             labelText += " - " + 
                          DurationUtils.timeAsLabelStr(task.getTotalTime()) +
                          " total for " + task.getTitle();
         }
+
+        // update total time label
+        this.totalLabel.setText("Total Time: " +
+                                DurationUtils.timeAsLabelStr(totalTime));
 
         // update the text of the internal label
         this.tasksLabel.setText(labelText);

--- a/src/org/ecs160/a2/ui/containers/TaskContainer.java
+++ b/src/org/ecs160/a2/ui/containers/TaskContainer.java
@@ -2,6 +2,7 @@ package org.ecs160.a2.ui.containers;
 
 import java.util.List;
 
+import com.codename1.components.SpanLabel;
 import com.codename1.ui.Label;
 import com.codename1.ui.layouts.BoxLayout;
 
@@ -16,24 +17,33 @@ import org.ecs160.a2.utils.UIUtils;
 public class TaskContainer extends UpdateableContainer 
                            implements AppConstants {
 
+    private SpanLabel tasksLabel;
+
     public TaskContainer () {
         super(new BoxLayout(BoxLayout.Y_AXIS));
+        this.tasksLabel = UIUtils.createSpanLabel("",
+                                                  NATIVE_LIGHT, 
+                                                  COLOR_REGULAR,
+                                                  FONT_SIZE_REGULAR);
+        this.add(this.tasksLabel);
     }
 
     /**
-     * Update the labels to reflect the times of the given Tasks
+     * Update the label to reflect the times of the given Tasks
      */
     @Override
     public void updateContainer(List<Task> taskList) {
-        // get a list of labels for the specified number of tasks
-        List<Label> labels = UIUtils.getLabelsToUpdate(this, 
-                                                       taskList.size());
+        String labelText = "";
         for (int i = 0; i < taskList.size(); i++) {
+            if (i > 0) labelText += "\n";
             Task task = taskList.get(i); // update the label w/ its
-            Label label = labels.get(i); // corresponding task
-            label.setText(" - " + 
-                          DurationUtils.timeAsLabelStr(task.getTotalTime()) +
-                          " total for " + task.getTitle());
+            labelText += " - " + 
+                         DurationUtils.timeAsLabelStr(task.getTotalTime()) +
+                         " total for " + task.getTitle();
         }
+        this.tasksLabel.setText(labelText);
+        if (labelText.length() == 0) this.tasksLabel.setHidden(true);
+        else this.tasksLabel.setHidden(false);
+        this.forceRevalidate();
     }
 }

--- a/src/org/ecs160/a2/utils/AppConstants.java
+++ b/src/org/ecs160/a2/utils/AppConstants.java
@@ -7,9 +7,9 @@ public interface AppConstants {
     Font NATIVE_LIGHT = Font.createTrueTypeFont("native:MainLight");
     Font NATIVE_REGULAR = Font.createTrueTypeFont("native:MainRegular");
     Font NATIVE_BOLD = Font.createTrueTypeFont("native:MainBold");
-    Font NATIVE_ITALIC_LIGHT = Font.createTrueTypeFont("native:ItalicLight");
-    Font NATIVE_ITALIC_REGULAR = Font.createTrueTypeFont("native:ItalicRegular");
-    Font NATIVE_ITALIC_BOLD = Font.createTrueTypeFont("native:ItalicBold");
+    Font NATIVE_ITAL_LIGHT = Font.createTrueTypeFont("native:ItalicLight");
+    Font NATIVE_ITAL_REGULAR = Font.createTrueTypeFont("native:ItalicRegular");
+    Font NATIVE_ITAL_BOLD = Font.createTrueTypeFont("native:ItalicBold");
 
     float FONT_SIZE_TITLE = 8.0f;
     float FONT_SIZE_SUB_TITLE = 5.0f;

--- a/src/org/ecs160/a2/utils/AppConstants.java
+++ b/src/org/ecs160/a2/utils/AppConstants.java
@@ -7,6 +7,9 @@ public interface AppConstants {
     Font NATIVE_LIGHT = Font.createTrueTypeFont("native:MainLight");
     Font NATIVE_REGULAR = Font.createTrueTypeFont("native:MainRegular");
     Font NATIVE_BOLD = Font.createTrueTypeFont("native:MainBold");
+    Font NATIVE_ITALIC_LIGHT = Font.createTrueTypeFont("native:ItalicLight");
+    Font NATIVE_ITALIC_REGULAR = Font.createTrueTypeFont("native:ItalicRegular");
+    Font NATIVE_ITALIC_BOLD = Font.createTrueTypeFont("native:ItalicBold");
 
     float FONT_SIZE_TITLE = 8.0f;
     float FONT_SIZE_SUB_TITLE = 5.0f;

--- a/src/org/ecs160/a2/utils/UIUtils.java
+++ b/src/org/ecs160/a2/utils/UIUtils.java
@@ -60,44 +60,6 @@ public class UIUtils implements AppConstants {
     }
 
     /**
-     * Get a list of labels to update in a container for the specified number
-     * 
-     * @param container  The container that houses the labels
-     * @param labelCount The number of labels that must be visible
-     * 
-     * @return List of visible labels from the specified container
-     */
-    public static List<Label> getLabelsToUpdate (Container container, 
-                                                 int labelCount) {
-        int i;
-        List<Label> returnLabels = new ArrayList<Label>();
-
-        // loop through the task list, adding new labels if necessary
-        for (i = 0; i < labelCount; i++) {
-            Label label;
-
-            if (i < container.getComponentCount()) {
-                label = (Label) container.getComponentAt(i);
-                if (label.isHidden()) label.setHidden(false);
-            } else {
-                label = createLabel("", NATIVE_LIGHT, COLOR_REGULAR, 
-                                    FONT_SIZE_REGULAR);
-                container.add(label);
-            }
-
-            returnLabels.add(label);
-        }
-
-        // hide the extra labels from the component
-        for (int j = i; j < container.getComponentCount(); j++) {
-            Component extraLabel = container.getComponentAt(i);
-            extraLabel.setHidden(true);
-        }
-
-        return returnLabels;
-    }
-
-    /**
      * @param size The CN1 "dips" to convert to pixels
      */
     public static int getPixelSize(float size) {

--- a/src/org/ecs160/a2/utils/UIUtils.java
+++ b/src/org/ecs160/a2/utils/UIUtils.java
@@ -1,5 +1,6 @@
 package org.ecs160.a2.utils;
 
+import com.codename1.components.SpanLabel;
 import com.codename1.ui.Component;
 import com.codename1.ui.Container;
 import com.codename1.ui.Display;
@@ -31,6 +32,29 @@ public class UIUtils implements AppConstants {
         label.getAllStyles().setFont(style.derive(pixelSize, 
                                                   Font.STYLE_PLAIN));
         label.getAllStyles().setFgColor(color);
+
+        return label;
+    }
+
+    /**
+     * Generate a multiline span label for the specified parameters
+     * 
+     * @param labelText The label's text
+     * @param style     The label's font
+     * @param color     The label's color
+     * @param fontSize  The label's size in CN1 "dips"
+     * 
+     * @return The newly generated label
+     */
+    public static SpanLabel createSpanLabel (String labelText, Font style, 
+                                             int color, 
+                                             float fontSize) {
+        SpanLabel label = new SpanLabel(labelText);
+
+        int pixelSize = Display.getInstance().convertToPixels(fontSize);
+        label.getTextAllStyles().setFont(style.derive(pixelSize, 
+                                                  Font.STYLE_PLAIN));
+        label.getTextAllStyles().setFgColor(color);
 
         return label;
     }

--- a/src/org/ecs160/a2/utils/UIUtils.java
+++ b/src/org/ecs160/a2/utils/UIUtils.java
@@ -1,15 +1,10 @@
 package org.ecs160.a2.utils;
 
 import com.codename1.components.SpanLabel;
-import com.codename1.ui.Component;
-import com.codename1.ui.Container;
 import com.codename1.ui.Display;
 import com.codename1.ui.Font;
 import com.codename1.ui.Label;
 import com.codename1.ui.FontImage;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public class UIUtils implements AppConstants {
     


### PR DESCRIPTION
Changes:
- Added "Tag" tab to the summary page
- Added time totals for Size and Task summaries
- Changed the way the labels are rendered for instant updates
- Summary page updates automatically when the tab is tapped
- Summary page tab buttons now show the currently selected tab (closer to Figma model)

Todo?:
- Graphs? Feel like it would get too cluttered the way it is right now